### PR TITLE
1 least authority audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ provides the encoding prefixes for the Mainnet, Testnet, and Regtest networks.
 A set of convenience methods: DecodeP2pkh(), DecodeP2sh(), DecodeSapling(), and DecodeOrchard()
 have been provided for direct decoding to a specific type.
 
+The length of the encoding is limited by f4jumble to 4194368 bytes in accordance with
+<https://zips.z.cash/zip-0316>
+
+A unified address contains a map of Unknown Encodings of unknown lengths.
+
+```Go
+type UnifiedAddress struct {
+  P2pkh   *[20]byte
+  P2sh    *[20]byte
+  Sapling *[43]byte
+  Orchard *[43]byte
+  Unknown map[uint64][]byte
+}
+```
+
+Entries in the `Unknown` map correspond to unified address receivers and metadata entries
+that do not correspond to typecodes understood by this library.
+
 Implementation patterns can be found in the zcashaddress_test.go found in this repository.
 
-Test Vectors in the file zcashaddress_test.go are a port of the vectors found at <https://github.com/zcash/zcash-test-vectors/blob/master/test-vectors/rust/unified_address.rs>
+Test Vectors in the file zcashaddress_test.go are a port of the vectors found at
+<https://github.com/zcash/zcash-test-vectors/blob/master/test-vectors/rust/unified_address.rs>

--- a/unifiedaddress/unifiedaddress.go
+++ b/unifiedaddress/unifiedaddress.go
@@ -18,11 +18,14 @@ type ItemType uint64
 // breaking the sequential order of items NoPreviousItem is a max value for ordering checks
 // in DecodeUnified()git
 const (
-	P2PKHItem      ItemType = 0x00
-	P2SHItem       ItemType = 0x01
-	SaplingItem    ItemType = 0x02
-	OrchardItem    ItemType = 0x03
-	NoPreviousItem ItemType = 0xffffffff
+	P2PKHItem              ItemType = 0x00
+	P2SHItem               ItemType = 0x01
+	SaplingItem            ItemType = 0x02
+	OrchardItem            ItemType = 0x03
+	NoPreviousItem         ItemType = 0xffffffff
+	MaxAllowedEncodingType          = 0x20000000
+	MaxLenM                         = 4194368
+	MinLenM                         = 48
 )
 
 func getExpectedLength(itemType ItemType) uint64 {
@@ -137,6 +140,12 @@ func EncodeUnified(addr *UnifiedAddress, hrp string) (string, error) {
 		}
 	}
 	for itemType, item := range addr.Unknown {
+		if itemType > MaxAllowedEncodingType {
+			return "", errors.New("item type out of range")
+		}
+		if len(item) > MaxLenM || len(item) < MinLenM {
+			return "", errors.New("invalid message length")
+		}
 		if len(item) > 0 {
 			tlvVal, err := tlv(uint64(itemType), item)
 			if err != nil {
@@ -187,7 +196,7 @@ func DecodeUnified(encoded, expectedHrp string) (*UnifiedAddress, error) {
 	if hrp != expectedHrp || encoding != nil {
 		return nil, errors.New("invalid HRP or encoding")
 	}
-	if len(data) < 48 {
+	if len(data) < MinLenM {
 		return nil, errors.New("invalid encoded data length")
 	}
 	convertedBits, convertedBitsErr := bech32.ConvertBits(data, 5, 8, false)
@@ -211,7 +220,12 @@ func DecodeUnified(encoded, expectedHrp string) (*UnifiedAddress, error) {
 	prevType := NoPreviousItem
 
 	for len(rest) > 0 {
-		itemType, remaining, e := compactsize.ParseCompactSize(rest, true)
+		itemTypeCode, remaining, e := compactsize.ParseCompactSize(rest, true)
+		// check max allowed encoding type
+		if prevType != NoPreviousItem && itemTypeCode > MaxAllowedEncodingType {
+			return nil, errors.New("item type out of range")
+		}
+		itemType := ItemType(itemTypeCode)
 
 		if e != nil {
 			return nil, fmt.Errorf("error decoding item type %w", e)
@@ -222,8 +236,7 @@ func DecodeUnified(encoded, expectedHrp string) (*UnifiedAddress, error) {
 			return nil, fmt.Errorf("error decoding item data %w", e2)
 		}
 
-		expectedLen := getExpectedLength(ItemType(itemType))
-
+		expectedLen := getExpectedLength(itemType)
 		if expectedLen > 0 && itemLen != expectedLen {
 			return nil, fmt.Errorf("incorrect item length for typecode %d", itemType)
 		}
@@ -232,20 +245,19 @@ func DecodeUnified(encoded, expectedHrp string) (*UnifiedAddress, error) {
 			return nil, fmt.Errorf("insufficient data for receiver with typecode %d", itemType)
 		}
 
-		item := remaining[:itemLen]
-		rest = remaining[itemLen:]
-
 		//check for duplicate names
-		if _, exists := receivers[itemType]; exists {
-			return nil, fmt.Errorf("duplicate %s item detected", getItemName(ItemType(itemType)))
+		if _, exists := receivers[itemTypeCode]; exists {
+			return nil, fmt.Errorf("duplicate %s item detected", getItemName(itemType))
 		}
 
-		receivers[itemType] = item
 		// check order of returns
-		if prevType != NoPreviousItem && ItemType(itemType) <= prevType {
+		if prevType != NoPreviousItem && itemType <= prevType {
 			return nil, errors.New("items out of order")
 		}
-		prevType = ItemType(itemType)
+
+		receivers[itemTypeCode] = remaining[:itemLen]
+		rest = remaining[itemLen:]
+		prevType = itemType
 	}
 
 	result := new(UnifiedAddress)

--- a/zcashaddress.go
+++ b/zcashaddress.go
@@ -101,9 +101,13 @@ func DecodeAddress(address string, network Network) (result ZcashAddress, err er
 			if humanReadablePrefix == network.texHRP {
 				conv, err := bech32.ConvertBits(bech32m_decoded_address, 5, 8, true)
 				if err == nil {
-					result.Tex = new([20]byte)
-					copy(result.Tex[:], conv)
-					return result, nil
+					if len(conv) == 20 {
+						result.Tex = new([20]byte)
+						copy(result.Tex[:], conv)
+						return result, nil
+					} else {
+						return result, errors.New("tex address data must be 20 bytes")
+					}
 				} else {
 					return result, err
 				}


### PR DESCRIPTION
This pull request addresses a set of changes recommended by the Least authority team.
1. Removed Panics from tlv() function in UnifiedAddress.go
2. Remove uint64 to in casting in UnifiedAddress.go
3. Add length check for `Tex` addresses in ZCashAddress.go
4. Updated README.md